### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+asgiref==3.3.1
+Django==3.1.5
+django-crispy-forms==1.10.0
+Pillow==8.1.0
+pytz==2020.5
+sqlparse==0.4.1


### PR DESCRIPTION
Adding `requirements.txt`

Peers can use the following command to get started after activating their `virtualenv`

> pip install -r /path/to/requirements.txt