### PR TITLE
Secret key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Django-WebApp/django_web_app/django_web_app/.env 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Django-WebApp/django_web_app/django_web_app/.env 
+Django-WebApp/env

--- a/django_web_app/django_web_app/.env
+++ b/django_web_app/django_web_app/.env
@@ -1,0 +1,1 @@
+SECRET_KEY='@5&-q%^o=@mb@=@e%b9yz^b#l-2)w&_s0ick#=wy3kw36$z($g'

--- a/django_web_app/django_web_app/settings.py
+++ b/django_web_app/django_web_app/settings.py
@@ -16,11 +16,16 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+import environ 
+#pip install environ
+env = environ.Env()
+environ.Env.read_env()
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '@5&-q%^o=@mb@=@e%b9yz^b#l-2)w&_s0ick#=wy3kw36$z($g'
+SECRET_KEY = env('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Keep the secret key secret because it can be responsible for vulnerable attacks if exposed.
Below are steps to follow:
1. install a package called  "environ" to read the content of .env files.
.env files contain sensitive info and should be kept secret and should not be pushed into git rep.
2. change settings.py to achieve the functionality of keeping the secret key secret.